### PR TITLE
Resolviendo error con la palabra clave Image

### DIFF
--- a/main.py
+++ b/main.py
@@ -103,8 +103,8 @@ def factoring(p):
             return None
         if hasWikidataImage(p) == False:
             if imagen.find('|') > -1:
-                match = re.match(r"\[{2}(Archivo|Media|File):(.[^\|]*)",\
-                                 imagen)
+                match = re.match(r"\[{2}(Archivo|Media|File|Imagen?):(.[^\|]*)",\
+                                 imagen,flags=re.IGNORECASE)
                 if match != None:
                     imagen = match.group(2)
             if imagen.lower().find('falta ') > -1 or imagen.find('{{') > -1:


### PR DESCRIPTION
El script falla si el enlace comienza por Imagen o Image, así mismo como si el espacio de nombres comienza con minúscula.

`[[imagen:Leganés - Barrio El Carrascal - Rotonda Fuente de Grecia 1.JPG\|280px]]`

