### PR TITLE
Cambiando de nombre de funciones y otros

### DIFF
--- a/commonscat.py
+++ b/commonscat.py
@@ -10,17 +10,6 @@ from pywikibot import pagegenerators
 from imagefinder import *
 from os import path, remove
 
-def hasWikidataCategory(page):
-    """
-    hasWikidataImage(page):
-        Retorna si el objeto en Wikidata
-        tiene una propiedad de imagen asociada o no
-    """
-    wikidataItem = getQ(page)
-    if wikidataItem != None:
-        return QhasP(wikidataItem, 'P373')
-    return None
-
 def main():
     ##Cleanup
     if path.isfile('hasno.csv'):
@@ -32,9 +21,9 @@ def main():
         if p.namespace() not in [0, 104] or p.title() in listaRevision:
             print ('<<< {0} skipped'.format(p.title()))
             continue
-        elif hasWikidataCategory(p) == False:
+        elif pageHasP(p, 'P373') == False:
             print ('>>> {0} has no P373'.format(p.title()))
-            lista = isInCategory(p, ['Commonscat', 'Commons cat', 'Categoría Commons', 'Commonscat-inline', 'Commons category', 'Commons category-inline'])
+            lista = hasTemplate(p, ['Commonscat', 'Commons cat', 'Categoría Commons', 'Commonscat-inline', 'Commons category', 'Commons category-inline'])
             parameters = (lista[0][1])
             if len(parameters) > 0:
                 category = parameters[0]

--- a/imagefinder.py
+++ b/imagefinder.py
@@ -67,9 +67,9 @@ def getCacheDump(dump='dump.csv'):
     except FileNotFoundError:
         return []
 
-def isInCategory(page, categoriesToCheck=[]):
+def hasTemplate(page, categoriesToCheck=[]):
     """
-    isInCategory(page, categoriesToCheck):
+    hasTemplate(page, categoriesToCheck):
         Determina si las categorias de una página está presente en
         las catregorias a comprobar
     """
@@ -82,7 +82,7 @@ def getParameter(page, templates=[], parameter=''):
         Obtiene un parametro desde las plantillas de búsqueda
         En caso de no encontrar el parámetro, retorna None
     """
-    templates = isInCategory(page, templates)
+    templates = hasTemplate(page, templates)
     for template, parameters in templates:
         for param in parameters:
             param = param.strip()


### PR DESCRIPTION
Eliminando función posiblemente duplicada (`hasWikidataCategory` desde commonscat.py) y renombrando función desde `isInCategory` a `hasTemplate` para hacerla un poco más semántica a la hora de usar la función.