### PR TITLE
Refactorizando un poquito + encabezado csv

### DIFF
--- a/imagefinder.py
+++ b/imagefinder.py
@@ -91,6 +91,14 @@ def getParameter(page, templates=[], parameter=''):
                 return None if len(parametro) == 0 else parametro
     return None
 
+def getLimite(site):
+    """
+    getLimite(site):
+        Obtiene el valor limite a obtener si el usuario actual es un bot o no
+        Se deja en 200, a pesar que el límite sean 500 por un tema de red
+    """
+    return 200 if site.isBot(site.username()) else 50
+
 def createJSON(dump, keys=[]):
     """
     createJSON(dump, keys):

--- a/main.py
+++ b/main.py
@@ -33,14 +33,6 @@ def saveOldDump(dump=DUMP):
         print('No old dump to save')
         return None
 
-def isInDump(titulo, titulos):
-    """
-    isInkDump(titulo, titulos):
-        Analiza si la linea investigada existe en el dump
-        True si está, False si no
-    """
-    return titulo in titulos
-
 def returnTemplates(templates):
     """
     returnTemplates(templates):
@@ -71,17 +63,6 @@ def getPhoto(params):
     imagen = imagen[0].split('=', 1)[1]
     return None if len(imagen.strip()) == 0 else imagen.strip()
 
-def hasWikidataImage(page):
-    """
-    hasWikidataImage(page):
-        Retorna si el objeto en Wikidata
-        tiene una propiedad de imagen asociada o no
-    """
-    wikidataItem = getQ(page)
-    if wikidataItem != None:
-        return QhasP(wikidataItem, 'P18')
-    return None
-
 def procesador(q, i):
     """
     procesador(q,i):
@@ -104,7 +85,7 @@ def factoring(p):
     imagen = getPhoto(lista_plantilla)
     if imagen == None:
         return None
-    if hasWikidataImage(p) == False:
+    if pageHasP(p, 'P18') == False:
         if imagen.find('|') > -1:
             match = re.match(r"\[{2}(Archivo|Media|File|Imagen?):(.[^\|]*)",\
                              imagen,flags=re.IGNORECASE)
@@ -143,6 +124,10 @@ def main():
         remove('dump_images.csv')
     saveOldDump()
 
+    printToCsv(line=\
+        ['Wikipedia', 'Imagen', 'URL Wikipedia', 'URL Q wikidata'],\
+        archivo='dump_images.csv')
+
     generador = pagegenerators.CategorizedPageGenerator(\
                                                     pywikibot.Category(\
                                                     pywikibot.Link(\
@@ -155,7 +140,7 @@ def main():
     lista_cache = getCacheDump('dump_skip.csv')
 
     for p in pages:
-        if isInDump(p.title(), lista_cache) == False:
+        if p.title() not in lista_cache:
             cola.put(p)
     cola.join()
     printHtml()

--- a/main.py
+++ b/main.py
@@ -132,8 +132,7 @@ def main():
                                                     pywikibot.Category(\
                                                     pywikibot.Link(\
                 'Category:Wikipedia:Artículos con coordenadas en Wikidata')))
-    LIMIT = 200 if SITE.isBot(SITE.username()) else 50
-    pages = pagegenerators.PreloadingGenerator(generador, LIMIT)
+    pages = pagegenerators.PreloadingGenerator(generador, getLimite(SITE))
     #for debug
     #pages = [pywikibot.Page(source=SITE,title='Þeistareykjarbunga')]
 


### PR DESCRIPTION
Este PR tiene por objetivo reducir la cantidad de funciones con otras que ya están reemplazadas dentro del código:

* Eliminé `hasWikidataImage` y la reemplacé por `pageHasP`, para eliminar la función local
* Eliminé `isInDump` ya que la única utilidad era determinar si una página `x` está en la lista `y`, cuestión que se reemplaza por `x in y` (o `x not in y` si se busca el falso)
* Añadí `getLimite` que permite obtener la cantidad máxima de páginas que se pueden precargar sin que aparezca el error de que la cuenta usada no es bot.

Además, se añade un encabezado al csv de salida con el fin de que el usuario que lea el archivo pueda conocer el contenido sin la necesidad de leer la ayuda (supondré que es buena práctica).