### PR TITLE
Mejoras en el script de Commons y unas yerbas más...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ throttle*
 __pycache__
 *.html
 *cache
+*.json

--- a/commonscat.py
+++ b/commonscat.py
@@ -28,9 +28,7 @@ def work(pages):
             printToCsv(line=[page.title()], archivo='has.csv')
 
 def write_result():
-    template = open('templates/commons.tpl').read()
-    archivo = open('commons.html', 'w')
-    archivo.write(template.format(getNow(), getGitVersion()))
+    write_file('templates/commons.tpl', 'commons.html', getNow(), getGitVersion())
 
 def main(*args):
     ##Cleanup

--- a/commonscat.py
+++ b/commonscat.py
@@ -15,6 +15,7 @@ def main():
     if path.isfile('hasno.csv'):
         remove('hasno.csv')
     site = pywikibot.Site('es', 'wikipedia')
+    commons = pywikibot.Site('commons', 'commons')
     listaRevision = getCacheDump('has.csv')
     generator = pagegenerators.ReferringPageGenerator(pywikibot.Page(source=site, title='Template:Commonscat'))
     for p in generator:
@@ -29,8 +30,11 @@ def main():
                 category = parameters[0]
             else:
                 category = p.title(withNamespace=False)
-            printToCsv(line=[p.full_url(),getQ(p).full_url(),p.title(),category], archivo='hasno.csv')
-            createJSON('hasno.csv', ['wikipedia', 'wikidata', 'article', 'category_commons'])
+            if pywikibot.Page(source=commons, title="Category:" + category).exists():
+                printToCsv(line=[p.full_url(),getQ(p).full_url(),p.title(),category], archivo='hasno.csv')
+                createJSON('hasno.csv', ['wikipedia', 'wikidata', 'article', 'category_commons'])
+            else:
+                printToCsv(line=[p.full_url()], archivo='delete.csv')
         else:
             print('{0} has P373'.format(p.title()))
             printToCsv(line=[p.title()], archivo='has.csv')

--- a/commonscat.py
+++ b/commonscat.py
@@ -14,21 +14,15 @@ def work(pages):
     listaRevision = getCacheDump('has.csv')
 
     for page in pages:
-        if page.exists() == False:
-            continue
-        if page.namespace() not in [0, 104] or page.title() in listaRevision:
+        if page.exists() == False or page.namespace() not in [0, 104] or page.title() in listaRevision:
             print ('<<< {0} skipped'.format(page.title()))
             continue
         elif pageHasP(page, 'P373') == False:
             print ('>>> {0} has no P373'.format(page.title()))
             lista = hasTemplate(page, ['Commonscat', 'Commons cat', 'Categoría Commons', 'Commonscat-inline', 'Commons category', 'Commons category-inline'])
             parameters = (lista[0][1])
-            if len(parameters) > 0:
-                category = parameters[0]
-            else:
-                category = page.title(withNamespace=False)
+            category = category[0].replace('1=', '') if len(parameters) > 0 else page.title(withNamespace=False)
             printToCsv(line=[page.full_url(),getQ(page).full_url(),page.title(),category], archivo='hasno.csv')
-            createJSON('hasno.csv', ['wikipedia', 'wikidata', 'article', 'category_commons'])
         else:
             print('{0} has P373'.format(page.title()))
             printToCsv(line=[page.title()], archivo='has.csv')
@@ -36,7 +30,7 @@ def work(pages):
 def write_result():
     template = open('templates/commons.tpl').read()
     archivo = open('commons.html', 'w')
-    archivo.write(template.format('a', getGitVersion()))
+    archivo.write(template.format(getNow(), getGitVersion()))
 
 def main(*args):
     ##Cleanup
@@ -53,6 +47,8 @@ def main(*args):
 
     if path.isfile('hasno.csv'):
         remove('hasno.csv')
+    if path.isfile('hasno.json'):
+        remove('hasno.json')
 
     work(pages)
     write_result()

--- a/imagefinder.py
+++ b/imagefinder.py
@@ -11,6 +11,8 @@ import csv
 import json
 import datetime
 from os import path, remove, chdir
+import subprocess
+
 
 def getQ(page):
     """
@@ -135,6 +137,21 @@ def getConfigFile(cwd, file="/.config"):
             return None
         return '.'+file
     return cwd+file
+
+def getGitVersion():
+    """
+    getGitVersion():
+        Obtiene la versión actual de la rama de git en el directorio de ejecución
+    """
+    return str(subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).strip(), 'utf8')
+
+def getNow(format='%Y/%m/%d %H:%M'):
+    """
+    getNow(format='%Y/%m/%d %H:%M'):
+        Obtiene la fecha en un formato determinado.
+        Más información en http://strftime.org/
+    """
+    return datetime.datetime.utcnow().strftime(format)
 
 def printHtml():
     """

--- a/imagefinder.py
+++ b/imagefinder.py
@@ -153,6 +153,22 @@ def getNow(format='%Y/%m/%d %H:%M'):
     """
     return datetime.datetime.utcnow().strftime(format)
 
+def write_file(template, output, *args):
+    """
+    write_file(template, output, *args)
+        Escribe un template en un archivo, usando las variables entregadas para el format
+    """
+    if path.isfile(template) == False:
+        print('Plantilla {0} no existe'.format(template))
+        return
+    template_file = open(template).read()
+    archivo = open(output, 'w')
+    try:
+        archivo.write(template_file.format(*args))
+    except:
+        print('No se puede escribir archivo {0}'.format(output))
+        return
+
 def printHtml():
     """
     printHTML():

--- a/templates/commons.tpl
+++ b/templates/commons.tpl
@@ -1,0 +1,22 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+
+  <title>Commons category findes</title>
+  <meta name="description" content="The HTML5 Herald">
+  <meta name="author" content="SitePoint">
+
+</head>
+
+<body>
+  <h2>A tool to find possible Commons category to Wikidata</h2>
+  <p>This tool is searching for categories added in Spanish Wikipedia templates and
+    don't exists on Wikidata (<a href="https://wikidata.org/wiki/Property:P373">property 373</a>)</p>
+    <p>Download the CSV - pipe "|" separator</p>
+    <p>Download the not exists categories in Spanish Wikipedia</p>
+    <p>Last run: {0}</p>
+    <p>Git version: {1}</p>
+</body>
+</html>

--- a/templates/commons.tpl
+++ b/templates/commons.tpl
@@ -4,16 +4,14 @@
 <head>
   <meta charset="utf-8">
 
-  <title>Commons category findes</title>
-  <meta name="description" content="The HTML5 Herald">
-  <meta name="author" content="SitePoint">
+  <title>Commons category</title>
 
 </head>
 
 <body>
   <h2>A tool to find possible Commons category to Wikidata</h2>
-  <p>This tool is searching for categories added in Spanish Wikipedia templates and
-    don't exists on Wikidata (<a href="https://wikidata.org/wiki/Property:P373">property 373</a>)</p>
+  <p>This tool is searching for Wikimedia Commons categories added in Spanish Wikipedia using the Commonscat templates and
+    that doesn't exist on Wikidata (using <a href="https://wikidata.org/wiki/Property:P373">property 373</a>)</p>
     <p>Download the CSV - pipe "|" separator</p>
     <p>Download the not exists categories in Spanish Wikipedia</p>
     <p>Last run: {0}</p>


### PR DESCRIPTION
Tras pensar un poco en cómo resolver algunos problemas de código, hice lo siguiente

* :beetle:  Para probar, permití que se use el parámetro `-page:` en la línea de comandos, para evitar tener un "debug" en el código 
* :timer_clock:  Creé una función que nos permite obtener la fecha en formato `YYYY/MM/DD HH:II` para estandarizar la salida de datos, puedes pasarle un formateo nuevo en caso de ser necesario 
* :hash:  Creé la función para obtener la versión (shortlog) de git en qué nos encontramos, solo en caso de dudas de no saber qué versión está en producción 
* :writing_hand:  Añadí una función que toma una plantilla (carpeta `templates/`), puede generar un archivo de salida usando los x argumentos que queden disponibles en tras los dos parámetros de función. En este caso, lo encapsulé en la función `write_result` en `commonscat.py` 

Además añadí `*.json` al gitignore por si generamos json en algún momento de la vida...

Eso